### PR TITLE
Fix for issue #74

### DIFF
--- a/Source/PageView/PageView.swift
+++ b/Source/PageView/PageView.swift
@@ -66,8 +66,10 @@ extension PageView {
         pageView.alpha = 0.4
         view.addSubview(pageView)
 
+      let layoutAttribs:[(NSLayoutAttribute, Int)] =  [(NSLayoutAttribute.left, 0), (NSLayoutAttribute.right, 0), (NSLayoutAttribute.bottom, Int(bottomConstant))]
+      
         // add constraints
-        for (attribute, const) in [(NSLayoutAttribute.left, 0), (NSLayoutAttribute.right, 0), (NSLayoutAttribute.bottom, bottomConstant)] {
+      for (attribute, const) in layoutAttribs {
             (view, pageView) >>>- {
                 $0.constant = CGFloat(const)
                 $0.attribute = attribute


### PR DESCRIPTION
Issue running Xcode beta 9.3 with PageView.swift at line 70 "Expression type '[Any]' is ambiguous without more context" fix by specifying type explicitly as [(NSLayoutAttribute, Int)], (for clarity used separate line to define).