### PR TITLE
Title margins

### DIFF
--- a/Source/OnboardingContentView/Item/OnboardingContantViewItem.swift
+++ b/Source/OnboardingContentView/Item/OnboardingContantViewItem.swift
@@ -110,12 +110,14 @@ private extension OnboardingContentViewItem {
             return
         }
 
-        for attribute in [NSLayoutConstraint.Attribute.centerX, NSLayoutConstraint.Attribute.leading, NSLayoutConstraint.Attribute.trailing] {
+        for (attribute, constant) in [(NSLayoutConstraint.Attribute.leading, 15), (NSLayoutConstraint.Attribute.trailing, -15)] {
             (onView, label) >>>- {
                 $0.attribute = attribute
+                $0.constant = CGFloat(constant)
                 return
             }
         }
+        
         return label
     }
 

--- a/Source/PageView/PageContainerView/PageContainer.swift
+++ b/Source/PageView/PageContainerView/PageContainer.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-class PageContrainer: UIView {
+class PageContainer: UIView {
 
     var items: [PageViewItem]?
     let space: CGFloat // space between items
@@ -35,7 +35,7 @@ class PageContrainer: UIView {
 
 // MARK: public
 
-extension PageContrainer {
+extension PageContainer {
 
     func currenteIndex(_ index: Int, duration: Double, animated _: Bool) {
         guard let items = self.items,
@@ -52,7 +52,7 @@ extension PageContrainer {
 
 // MARK: animations
 
-extension PageContrainer {
+extension PageContainer {
 
     fileprivate func animationItem(_ item: PageViewItem, selected: Bool, duration: Double, fillColor: Bool = false) {
         let toValue = selected == true ? selectedItemRadius * 2 : itemRadius * 2
@@ -72,7 +72,7 @@ extension PageContrainer {
 
 // MARK: create
 
-extension PageContrainer {
+extension PageContainer {
 
     fileprivate func createItems(_ count: Int, radius: CGFloat, selectedRadius: CGFloat, itemColor: (Int) -> UIColor) -> [PageViewItem] {
         var items = [PageViewItem]()

--- a/Source/PageView/PageView.swift
+++ b/Source/PageView/PageView.swift
@@ -25,7 +25,7 @@ class PageView: UIView {
     }
 
     fileprivate var containerX: NSLayoutConstraint?
-    var containerView: PageContrainer?
+    var containerView: PageContainer?
 
     init(frame: CGRect, itemsCount: Int, radius: CGFloat, selectedRadius: CGFloat, itemColor: @escaping (Int) -> UIColor) {
         self.itemsCount = itemsCount
@@ -119,8 +119,8 @@ extension PageView {
 
 extension PageView {
 
-    fileprivate func createContainerView() -> PageContrainer {
-        let pageControl = PageContrainer(radius: itemRadius,
+    fileprivate func createContainerView() -> PageContainer {
+        let pageControl = PageContainer(radius: itemRadius,
                                          selectedRadius: selectedItemRadius,
                                          space: space,
                                          itemsCount: itemsCount,


### PR DESCRIPTION
Currently, the description has 30px margins, but the title has no margins. Depending on the title, it might happen that the title fills the whole onboarding view width:
![5.0](https://user-images.githubusercontent.com/170201/51175791-8c1a5e00-18bb-11e9-9a11-f467f5cc09b9.jpg)

I suggest there should be a margin so that the layout looks nicer in such cases:
![larger_titles](https://user-images.githubusercontent.com/170201/51175847-b3712b00-18bb-11e9-8bef-e275cd90fccd.jpg)

Since the description margin is currently hardcoded (30px), I hardcoded a title margin as well (15px, half the title margin). 

I did not introduce any margin customization mechanism at the moment, but this could be a possible improvement. How this could be achieved would probably require some discussion with you first.

Thanks in advance for considering this pull request!

#### Remark

When reading the code, I stumbled upon a class typo I fixed as well.






