### PR TITLE
Allow swiping on iOS 13 page sheet

### DIFF
--- a/Source/GestureControl/GestureControl.swift
+++ b/Source/GestureControl/GestureControl.swift
@@ -26,10 +26,12 @@ public class GestureControl: UIView {
 
         swipeLeft = UISwipeGestureRecognizer(target: self, action: #selector(GestureControl.swipeHandler(_:)))
         swipeLeft.direction = .left
+        swipeLeft.delegate = self  /// reference the gesture recognizer delegate
         addGestureRecognizer(swipeLeft)
 
         swipeRight = UISwipeGestureRecognizer(target: self, action: #selector(GestureControl.swipeHandler(_:)))
         swipeRight.direction = .right
+        swipeRight.delegate = self /// reference the gesture recognizer delegate
         addGestureRecognizer(swipeRight)
 
         translatesAutoresizingMaskIntoConstraints = false
@@ -47,6 +49,18 @@ public class GestureControl: UIView {
 
     required init?(coder _: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// MARK: Gesture recognizer delegate
+/// the default modal presentation style in iOS 13 is a page sheet
+/// if Paper Onboarding is presented as a page sheet, this function is **required to enable swiping**
+/// because there is a built-in gesture (that dismisses the page sheet) which conflicts with the swipe gesture
+///
+/// with this function, **both the swipe gesture and the built-in gesture work!**
+extension GestureControl: UIGestureRecognizerDelegate {
+    public func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer, shouldBeRequiredToFailBy otherGestureRecognizer: UIGestureRecognizer) -> Bool {
+        return true
     }
 }
 


### PR DESCRIPTION
Conform to `gestureRecognizer(_:shouldBeRequiredToFailBy:)`.
More technical details [here](https://developer.apple.com/documentation/uikit/uigesturerecognizerdelegate/1624222-gesturerecognizer).

Fixes [issue 111](https://github.com/Ramotion/paper-onboarding/issues/111) and also [issue 116 ](https://github.com/Ramotion/paper-onboarding/issues/116) (iOS 13 page sheet's built-in gesture conflicts with the swipe gesture). These issues are closed, but only a workaround was found (presenting the view controller in full screen). By returning `true` in `gestureRecognizer(_:shouldBeRequiredToFailBy:)`, you can present the view controller however you want.

And even if you present via page sheet, **both** the built-in dismiss gesture and the swipe gesture work. Tested on iOS 13.5.1 and iPadOS 13.5.1.
