### PR TITLE
lil fix for rtl languages

### DIFF
--- a/Source/PageView/PageView.swift
+++ b/Source/PageView/PageView.swift
@@ -166,8 +166,14 @@ extension PageView {
         }
 
         let containerWidth = CGFloat(itemsCount + 1) * selectedItemRadius + space * CGFloat(itemsCount - 1)
-        let toValue = containerWidth / 2.0 - selectedItemRadius - (selectedItemRadius + space) * CGFloat(index)
-        containerX.constant = toValue
+        if UIApplication.shared.userInterfaceLayoutDirection == .leftToRight {
+            let toValue = containerWidth / 2.0 - selectedItemRadius - (selectedItemRadius + space) * CGFloat(index)
+            containerX.constant = toValue
+        } else {
+            let toValue = containerWidth / 2.0 + selectedItemRadius + (selectedItemRadius + space) * CGFloat(index)
+            containerX.constant = toValue
+        }
+        
 
         if animated == true {
             UIView.animate(withDuration: duration,


### PR DESCRIPTION
Hello!
This is a fix for using this library with rtl (right to left, e.g. Arabic) languages. Without this fix, the position of the dots is not correct and could go out of screen. Of course, it will work the same when using ltr language.