### PR TITLE
Fix RTL interfaces

### DIFF
--- a/Source/GestureControl/GestureControl.swift
+++ b/Source/GestureControl/GestureControl.swift
@@ -55,6 +55,16 @@ public class GestureControl: UIView {
 extension GestureControl {
 
     @objc dynamic func swipeHandler(_ gesture: UISwipeGestureRecognizer) {
-        delegate.gestureControlDidSwipe(gesture.direction)
+        var direction = gesture.direction
+        let isRTL = UIView.userInterfaceLayoutDirection(for: gesture.view!.semanticContentAttribute) == .rightToLeft
+
+        // Flip direction only if in RTL interface
+        if (isRTL && direction == .right) {
+            direction = .left
+        } else if (isRTL && direction == .left) {
+            direction = .right
+        }
+        
+        delegate.gestureControlDidSwipe(direction)
     }
 }

--- a/Source/PageView/PageView.swift
+++ b/Source/PageView/PageView.swift
@@ -166,7 +166,10 @@ extension PageView {
         }
 
         let containerWidth = CGFloat(itemsCount + 1) * selectedItemRadius + space * CGFloat(itemsCount - 1)
-        let toValue = containerWidth / 2.0 - selectedItemRadius - (selectedItemRadius + space) * CGFloat(index)
+        
+        let isRTL = UIView.userInterfaceLayoutDirection(for: self.semanticContentAttribute) == .rightToLeft
+        let sign: CGFloat = isRTL ? 1 : -1
+        let toValue = containerWidth / 2.0 + sign * (selectedItemRadius + (selectedItemRadius + space) * CGFloat(index))
         containerX.constant = toValue
 
         if animated == true {


### PR DESCRIPTION
RTL interfaces are broken: the dots move in the opposite direction and the user has to swipe in the opposite direction of their language. 
This PR fixes both issues. LTR languages are intact. Tested with both English (LTR) and Arabic (RTL).