### PR TITLE
Remove deprecation

### DIFF
--- a/Source/GestureControl/GestureControl.swift
+++ b/Source/GestureControl/GestureControl.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol GestureControlDelegate: AnyObject {
+protocol GestureControlDelegate: class {
     func gestureControlDidSwipe(_ direction: UISwipeGestureRecognizer.Direction)
 }
 

--- a/Source/GestureControl/GestureControl.swift
+++ b/Source/GestureControl/GestureControl.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol GestureControlDelegate: class {
+protocol GestureControlDelegate: AnyObject {
     func gestureControlDidSwipe(_ direction: UISwipeGestureRecognizer.Direction)
 }
 

--- a/Source/OnboardingContentView/OnboardingContentView.swift
+++ b/Source/OnboardingContentView/OnboardingContentView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol OnboardingContentViewDelegate: class {
+protocol OnboardingContentViewDelegate: AnyObject {
 
     func onboardingItemAtIndex(_ index: Int) -> OnboardingItemInfo?
     func onboardingConfigurationItem(_ item: OnboardingContentViewItem, index: Int)

--- a/Source/OnboardingContentView/OnboardingContentView.swift
+++ b/Source/OnboardingContentView/OnboardingContentView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol OnboardingContentViewDelegate: AnyObject {
+protocol OnboardingContentViewDelegate: class {
 
     func onboardingItemAtIndex(_ index: Int) -> OnboardingItemInfo?
     func onboardingConfigurationItem(_ item: OnboardingContentViewItem, index: Int)


### PR DESCRIPTION
Updated Delegate to remove the deprecated "class" conformation.
Using 'class' keyword to define a class-constrained protocol is deprecated; use 'AnyObject' instead => Update to AnyObject